### PR TITLE
Only target fullscreen videos

### DIFF
--- a/chrome/video-fixer.css
+++ b/chrome/video-fixer.css
@@ -1,3 +1,3 @@
-video {
+video:fullscreen {
   opacity: 0.996 !important;
 }


### PR DESCRIPTION
Hey @clundie, first thanks so much for this extension. I was switching to another browser each evening because of this bug 👍 

I was curious about how you achieved this and I got it, you give it a layer. Still you do this for every video of every page. This PR only targets fullscreen videos so your plugin only comes in when specifically needed.

Thanks!